### PR TITLE
Provide an explicit error schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 gtfs_tripify.egg-info/
 notebooks/
 .vscode
+dist/
+build/

--- a/tests/io_tests.py
+++ b/tests/io_tests.py
@@ -27,7 +27,7 @@ class TestLogbooksToGTFS(unittest.TestCase):
 
         self.log_0 = dictify(gtfs_0)
         self.log_1 = dictify(gtfs_1)
-        self.logbook, _ = logify([self.log_0, self.log_1])
+        self.logbook, _, _ = logify([self.log_0, self.log_1])
 
         for unique_trip_id in self.logbook:
             self.logbook[unique_trip_id].maximum_time = 1556588500
@@ -54,7 +54,7 @@ class TestLogbooksToCSV(unittest.TestCase):
 
         self.log_0 = dictify(gtfs_0)
         self.log_1 = dictify(gtfs_1)
-        self.logbook, _ = logify([self.log_0, self.log_1])
+        self.logbook, _, _ = logify([self.log_0, self.log_1])
 
     def test_to_csv_roundtrip(self):
         to_csv(self.logbook, 'temp.csv')

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -21,24 +21,27 @@ class TestCutCancellations(unittest.TestCase):
         The heuristic should do nothing if the log is empty.
         """
         log = pd.DataFrame(columns=self.log_columns)
-        result = cut_cancellations(log)
-        assert len(result) == 0
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 0
 
     def test_zero_confirmed(self):
         """
         The heuristic should return an empty log if there are zero confirmed stops in the log.
         """
         log = pd.DataFrame(columns=self.log_columns, data=[['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', '_']])
-        result = cut_cancellations(log)
-        assert len(result) == 0
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 0
 
     def test_zero_tailing_unconfirmed(self):
         """
         The heuristic should return an unmodified log if there are no tailing `STOPPED_OR_SKIPPED` records.
         """
         log = pd.DataFrame(columns=self.log_columns, data=[['_', '_', 'STOPPED_AT', '_', '_', '_', '_']])
-        result = cut_cancellations(log)
-        assert len(result) == 1
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 1
 
     def test_one_tailing_unconfirmed(self):
         """
@@ -49,8 +52,9 @@ class TestCutCancellations(unittest.TestCase):
                                ['_', '_', 'STOPPED_AT', '_', '_', '_', '_'],
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', '_']
                            ])
-        result = cut_cancellations(log)
-        assert len(result) == 2
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 2
 
     def test_many_unique_tailing_unconfirmed(self):
         """
@@ -63,8 +67,9 @@ class TestCutCancellations(unittest.TestCase):
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 0],
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 1]
                            ])
-        result = cut_cancellations(log)
-        assert len(result) == 3
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 3
 
     def test_many_nonunique_tailing_unconfirmed(self):
         """
@@ -77,8 +82,9 @@ class TestCutCancellations(unittest.TestCase):
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 1],
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 1]
                            ])
-        result = cut_cancellations(log)
-        assert len(result) == 1
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 1
 
     def test_many_nonunique_tailing_unconfirmed_stop_skip(self):
         """
@@ -92,8 +98,9 @@ class TestCutCancellations(unittest.TestCase):
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 1],
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 1]
                            ])
-        result = cut_cancellations(log)
-        assert len(result) == 1
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 1
 
     def test_many_unconfirmed_stop_skip(self):
         """
@@ -105,8 +112,9 @@ class TestCutCancellations(unittest.TestCase):
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 0],
                                ['_', '_', 'STOPPED_OR_SKIPPED', '_', '_', '_', 0]
                            ])
-        result = cut_cancellations(log)
-        assert len(result) == 0
+        logbook = {'uuid': log}
+        result = cut_cancellations(logbook)
+        assert len(result['uuid']) == 0
 
 
 class TestDiscardPartialLogs(unittest.TestCase):


### PR DESCRIPTION
Parse errors are now a first-class object returned by `gt.logify`.